### PR TITLE
Fix typo in variable name

### DIFF
--- a/flask_pydantic_api/openapi.py
+++ b/flask_pydantic_api/openapi.py
@@ -20,7 +20,7 @@ try:
     )
 except ImportError:
     model_has_fieldsets_defined = None
-    FeildsetGenerateJsonSchema = None
+    FieldsetGenerateJsonSchema = None
 
 
 def get_pydantic_api_path_operations(


### PR DESCRIPTION
Hello! A quick PR to fix a typo in a variable name.

`FeildsetGenerateJsonSchema` -> `FieldsetGenerateJsonSchema`

Thanks!